### PR TITLE
Updated DeepSource for Browser API's

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,7 +5,7 @@ name = "javascript"
 enabled = true
 
   [analyzers.meta]
-  environment = ["nodejs"]
+  environment = ['nodejs', 'browser']
   plugins = ["react"]
   style_guide = "airbnb"
   dialect = "typescript"


### PR DESCRIPTION
Hi, 

I noticed you've reported some false positive reports for **JS-0125: Found the usage of undeclared variables**.
The report for the browser APIs has been fixed by enabling the `browser` environment in the DeepSource configuration file.

Signed-off-by: Moulik Aggarwal <moulik@deepsource.io>